### PR TITLE
Add an rmdepcheck test for updates

### DIFF
--- a/lib/installedtest.pm
+++ b/lib/installedtest.pm
@@ -35,6 +35,8 @@ sub root_console {
 sub post_fail_hook {
     my $self = shift;
 
+    return if get_var("TEST") eq 'rmdepcheck';
+
     if (check_screen ['emergency_rescue', 'emergency_rescue_nopassword'], 3) {
         if (match_has_tag 'emergency_rescue') {
             my $password = get_var("ROOT_PASSWORD", "weakpassword");

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -6,7 +6,7 @@ use base 'Exporter';
 use Exporter;
 use lockapi;
 use testapi qw(is_serial_terminal :DEFAULT);
-our @EXPORT = qw/run_with_error_check type_safely type_very_safely desktop_vt boot_to_login_screen console_login console_switch_layout desktop_switch_layout console_loadkeys_us do_bootloader boot_decrypt check_release menu_launch_type setup_repos repo_setup get_workarounds disable_updates_repos cleanup_workaround_repo console_initial_setup handle_welcome_screen gnome_initial_setup check_desktop quit_firefox advisory_get_installed_packages acnp_handle_output advisory_check_nonmatching_packages start_with_launcher quit_with_shortcut disable_firefox_studies select_rescue_mode copy_devcdrom_as_isofile get_release_number check_left_bar check_top_bar check_prerelease check_version spell_version_number _assert_and_click is_branched rec_log repos_mirrorlist register_application get_registered_applications desktop_launch_terminal solidify_wallpaper check_and_install_git download_testdata make_serial_writable set_update_notification_timestamp kde_doublek_workaround dm_perform_login check_software_start/;
+our @EXPORT = qw/run_with_error_check type_safely type_very_safely desktop_vt boot_to_login_screen console_login console_switch_layout desktop_switch_layout console_loadkeys_us do_bootloader boot_decrypt check_release menu_launch_type prepare_update_mount setup_repos repo_setup get_workarounds disable_updates_repos cleanup_workaround_repo console_initial_setup handle_welcome_screen gnome_initial_setup check_desktop quit_firefox advisory_get_installed_packages acnp_handle_output advisory_check_nonmatching_packages start_with_launcher quit_with_shortcut disable_firefox_studies select_rescue_mode copy_devcdrom_as_isofile get_release_number check_left_bar check_top_bar check_prerelease check_version spell_version_number _assert_and_click is_branched rec_log repos_mirrorlist register_application get_registered_applications desktop_launch_terminal solidify_wallpaper check_and_install_git download_testdata make_serial_writable set_update_notification_timestamp kde_doublek_workaround dm_perform_login check_software_start/;
 
 
 # We introduce this global variable to hold the list of applications that have
@@ -535,7 +535,7 @@ sub _repo_setup_compose {
     # }
 }
 
-sub _prepare_update_mount {
+sub prepare_update_mount {
     # create and mount the filesystem where we will store update/task packages
     # this is separate from setup_repos as it has to happen before we
     # enter the toolbox container on the CANNED workflow
@@ -719,7 +719,7 @@ sub _repo_setup_updates {
     console_login();
     # prepare the directory the packages will be downloaded to, unless we're
     # testing a side tag or COPR
-    _prepare_update_mount() unless ($tag || $copr);
+    prepare_update_mount() unless ($tag || $copr);
 
     # on CANNED, we need to enter the toolbox at this point
     if (get_var("CANNED")) {

--- a/templates-updates.fif.json
+++ b/templates-updates.fif.json
@@ -476,6 +476,18 @@
                 "updates-server-2arch": 5
             }
         },
+        "rmdepcheck": {
+            "profiles": {
+                "fedora-updates-everything-boot-iso-x86_64-*-64bit": 5
+            },
+            "settings": {
+                "BOOTFROM": "c",
+                "ENTRYPOINT": "rmdepcheck",
+                "HDD_1": "disk_f%CURRREL%_support_6_%ARCH%.qcow2",
+                "ROOT_PASSWORD": "weakpassword",
+                "USER_LOGIN": "false"
+            }
+        },
         "rpmostree_overlay": {
             "profiles": {
                 "fedora-updates-silverblue-dvd_ostree-iso-x86_64-*-64bit": 5

--- a/tests/rmdepcheck.pm
+++ b/tests/rmdepcheck.pm
@@ -1,0 +1,62 @@
+use base "installedtest";
+use strict;
+use testapi;
+use utils;
+
+sub run {
+    my $self = shift;
+    my $relnum = get_release_number;
+    my $version = get_var("VERSION");
+    my $arch = get_var("ARCH");
+    my $tag = get_var("TAG");
+    my $copr = get_var("COPR");
+    boot_to_login_screen;
+    $self->root_console(tty => 3);
+    assert_script_run 'systemctl start serial-getty@hvc1.service' if (get_var("OFW"));
+    script_run "echo 'Running on serial console...'";
+    select_console("virtio-console");
+    console_login();
+    prepare_update_mount() unless ($tag || $copr);
+    setup_repos(configs => 0);
+    my $nmbaserepo;
+    my $baserepo;
+    if (lc($version) eq "eln") {
+        $baserepo = "https://kojipkgs.fedoraproject.org/repos/eln-build/latest/${arch}";
+    }
+    else {
+        $baserepo = "https://kojipkgs.fedoraproject.org/repos/f${relnum}-build/latest/${arch}";
+    }
+    if (get_workarounds($version)) {
+        # er. is this right? it's hard to reason about...
+        $nmbaserepo = 'file:///mnt/workarounds_repo';
+    }
+    assert_script_run 'cd /var/tmp';
+    assert_script_run "dnf -y install zstd curl git", 300;
+    assert_script_run "git clone https://codeberg.org/AdamWill/rmdepcheck.git";
+    assert_script_run "cd rmdepcheck";
+    my $cmd = "./rmdepcheck.py";
+    $cmd .= " --nmbaserepos ${nmbaserepo}" if ($nmbaserepo);
+    $cmd .= " ${baserepo} ";
+    if ($tag || $copr) {
+        $cmd .= get_var("UPDATE_OR_TAG_REPO");
+    }
+    else {
+        $cmd .= 'file:///mnt/update_repo';
+    }
+    $cmd .= ' > /tmp/rmdepcheck.txt';
+    my $res = script_run $cmd, 300;
+    if ($res) {
+        my $message = script_output 'cat /tmp/rmdepcheck.txt';
+        $self->record_resultfile('rmdepcheck', $message, result => 'fail');
+        die 'rmdepcheck failed, check previous frame for output';
+    }
+}
+
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+
+# vim: set sw=4 et:


### PR DESCRIPTION
This adds an update test that runs the rmdepcheck dependency check tool on the update under test. This is not intended for long-term production use, but as a PoC for testing with rmdepcheck. Long- term production deployment is expected to be in Fedora CI.