### PR TITLE
_check_install_source: drop old stuff, update for dnf5

### DIFF
--- a/tests/_check_install_source.pm
+++ b/tests/_check_install_source.pm
@@ -23,19 +23,19 @@ sub run {
     if ($addrepourl) {
         if ($addrepourl =~ m,^nfs://,,) {
             # this line tells us it set up a repo for our URL.
-            # "repo addrepo" is older format from before Fedora 37,
-            # "Add the 'addrepo" is newer format from F37+
-            if (script_run 'grep "\(repo \|Add the \'\)addrepo.*' . ${addrepourl} . '" /tmp/packaging.log') {
-                # newer path from f39+: message is in syslog and look a bit different
-                assert_script_run 'grep "Add the \'addrepo.*file:///run/install/sources/mount-.000-nfs-device" /tmp/syslog';
-            }
+            assert_script_run 'grep "Add the \'addrepo.*file:///run/install/sources/mount-.000-nfs-device" /tmp/syslog';
             # ...this line tells us it added the repo called 'addrepo'
-            assert_script_run 'grep "Added the \'addrepo\'" /tmp/anaconda.log /tmp/syslog';
-            # ...and this tells us it worked (I hope).
-            assert_script_run 'grep "Load metadata for the \'addrepo\'" /tmp/anaconda.log /tmp/syslog';
-            # addrepo.nfs is from before Fedora 39, sources/mount-1000-nfs-device
-            # or mount-0000-nfs-device is from F39+
-            assert_script_run 'grep -E "Loaded metadata from.*file:///run/install/(addrepo.nfs|sources/mount-.000-nfs-device)" /tmp/anaconda.log /tmp/syslog';
+            assert_script_run 'grep "Added the \'addrepo\'" /tmp/syslog';
+            # ...and this tells us it worked (I hope). This is for dnf4
+            if (script_run 'grep "Load metadata for the \'addrepo\'" /tmp/syslog') {
+                # this is dnf5 - switched in F43, 2025-07
+                assert_script_run 'grep "Loading repomd and primary for repo .addrepo." /tmp/dnf.log';
+            }
+            # dnf4 again
+            if (script_run 'grep -E "Loaded metadata from.*file:///run/install/sources/mount-.000-nfs-device" /tmp/syslog') {
+                # dnf5
+                assert_script_run 'grep "Writing primary cache for repo .addrepo." /tmp/dnf.log';
+            }
         }
     }
     if ($repourl =~ /^hd:/) {
@@ -56,27 +56,19 @@ sub run {
         # there are only three hard problems in software development:
         # naming things, cache expiry, off-by-one errors...and quoting
         assert_script_run 'grep "Added the \'anaconda\'" /tmp/anaconda.log /tmp/syslog';
-        assert_script_run 'grep "Load metadata for the \'anaconda\'" /tmp/anaconda.log /tmp/syslog';
-        assert_script_run 'grep "Loaded metadata from.*' . ${repourl} . '" /tmp/anaconda.log /tmp/syslog';
+        if (script_run 'grep "Load metadata for the \'anaconda\'" /tmp/anaconda.log /tmp/syslog') {
+            # dnf5
+            assert_script_run 'grep "Loading repomd and primary for repo .anaconda." /tmp/dnf.log';
+        }
+        if (script_run 'grep "Loaded metadata from.*' . ${repourl} . '" /tmp/anaconda.log /tmp/syslog') {
+            assert_script_run 'grep "Writing primary cache for repo .anaconda." /tmp/dnf.log';
+        }
     }
-    if ($repourl) {
-        # check we don't have an error indicating our repo wasn't used.
-        # we except error with 'cdrom/file' in it because this error:
-        # base repo (cdrom/file:///run/install/repo) not valid -- removing it
-        # *always* happens when booting a netinst (that's just anaconda
-        # trying to use the image itself as a repo and failing because it's
-        # not a DVD), and this was causing false failures when running
-        # universal tests on netinsts
-        assert_script_run '! grep "base repo.*not valid" /tmp/packaging.log | grep -v "cdrom/file"';
-        # above form is before 3b5f8f4a61 , below form is after it; we
-        # don't seem to get the error for the cdrom repo on netinsts as
-        # of Fedora-Rawhide-20230414.n.0 at least. I'm not 100% sure
-        # where this message would wind up, so check everywhere
-        assert_script_run '! grep "base repository is invalid" /tmp/packaging.log /tmp/anaconda.log /tmp/syslog';
-    }
-    # just for convenience - sometimes it's useful to see this log
+    # just for convenience - sometimes it's useful to see these logs
     # for a success case
     upload_logs "/tmp/packaging.log", failok => 1;
+    upload_logs "/tmp/dnf.log", failok => 1;
+    upload_logs "/tmp/syslog", failok => 1;
     select_console "tty6-console";
 
     # Anaconda hub


### PR DESCRIPTION
All the old patterns we accept and differing files they might be in are obsolete now, I'm pretty sure - I checked that in F41 tests we get the most recent messages and they're all in syslog. So drop all of those. But we need to add new handling for dnf5, now anaconda switched to that and the messages changed again.

I can't find any messages in the dnf5 logs that confirm the correct URL was used, unfortunately - these are the best I can find.

Also, since 31cd5e7 , we won't get the base repository error strings we're looking for any more, even if there *is* a problem with the base repo. I don't think there's any single error we can rely on getting any more, so we'll have to trust that the other checks are sufficient, or figure out ones to add as we go along if not.