### PR TITLE
Run desktop_login test on updates

### DIFF
--- a/templates-updates.fif.json
+++ b/templates-updates.fif.json
@@ -319,6 +319,12 @@
                 "fedora-updates-workstation-x86_64-*-64bit": 5
             }
         },
+        "desktop_login": {
+            "profiles": {
+                "fedora-updates-kde-x86_64-*-64bit": 32,
+                "fedora-updates-workstation-x86_64-*-64bit": 30
+            }
+        },
         "desktop_printing": {
             "profile_groups": {
                 "updates-desktops": 5

--- a/tests/desktop_login.pm
+++ b/tests/desktop_login.pm
@@ -349,6 +349,12 @@ sub run {
     }
     # Power off the machine
     power_off();
+    if (get_var("ADVISORY_OR_TASK")) {
+        # power back on for _advisory_post
+        sleep 5;
+        power("reset");
+        boot_to_login_screen(timeout => 180);
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
It's a useful test. This requires us to power back on at the end of the test so _advisory_post can run.