### PR TITLE
Build and test cloud image in updates tests

### DIFF
--- a/lib/mock.pm
+++ b/lib/mock.pm
@@ -36,7 +36,7 @@ sub mock_setup {
     assert_script_run 'echo "config_opts[\'plugin_conf\'][\'bind_mount_enable\'] = True" >> /etc/mock/openqa.cfg';
     assert_script_run 'echo "config_opts[\'plugin_conf\'][\'bind_mount_opts\'][\'dirs\'].append((\'/mnt/update_repo\', \'/mnt/update_repo\'))" >> /etc/mock/openqa.cfg' unless ($tag || $copr);
     assert_script_run 'echo "config_opts[\'plugin_conf\'][\'bind_mount_opts\'][\'dirs\'].append((\'/mnt/workarounds_repo\', \'/mnt/workarounds_repo\'))" >> /etc/mock/openqa.cfg' if ($workarounds);
-    assert_script_run 'echo "config_opts[\'plugin_conf\'][\'bind_mount_opts\'][\'dirs\'].append((\'/dev/' . $serialdev . '\', \'/dev/' . $serialdev . '\'))" >> /etc/mock/openqa.cfg';
+    assert_script_run 'echo "config_opts[\'plugin_conf\'][\'bind_mount_opts\'][\'dirs\'].append((\'/dev/\', \'/dev/\'))" >> /etc/mock/openqa.cfg';
     my $repos = 'config_opts[\'dnf.conf\'] += \"\"\"\n';
     # add the update, tag or COPR repo to the config
     $repos .= '[advisory]\nname=Advisory repo\nbaseurl=file:///mnt/update_repo\nenabled=1\nmetadata_expire=3600\ngpgcheck=0\n' unless ($tag || $copr);

--- a/templates-updates.fif.json
+++ b/templates-updates.fif.json
@@ -1,8 +1,20 @@
 {
     "Flavors": {
+        "updates-cloud": {
+            "settings": {
+                "HDD_1": "Fedora.%ARCH%-%VERSION%.qcow2",
+                "ISO": "cloudinit.iso",
+                "KIWI_PROFILE": "Cloud-Base-Generic",
+                "NUMDISKS": "2",
+                "RETRY": "1",
+                "+START_AFTER_TEST": "kiwi_build@%ARCH_BASE_MACHINE%",
+                "SUBVARIANT": "Cloud"
+            }
+        },
         "updates-container": {
             "settings": {
                 "+HDD_1": "disk_f%VERSION%_server_5_%ARCH%.qcow2",
+                "KIWI_PROFILE": "Container-Base-Generic",
                 "NUMDISKS": "2",
                 "RETRY": "1"
             }
@@ -92,6 +104,20 @@
         "version": "*"
     },
     "Products": {
+        "fedora-updates-cloud-aarch64-*": {
+            "arch": "aarch64",
+            "flavor": "updates-cloud",
+            "group_name": "Fedora AArch64 Updates"
+        },
+        "fedora-updates-cloud-ppc64le-*": {
+            "arch": "ppc64le",
+            "flavor": "updates-cloud",
+            "group_name": "Fedora PowerPC Updates"
+        },
+        "fedora-updates-cloud-x86_64-*": {
+            "arch": "x86_64",
+            "flavor": "updates-cloud"
+        },
         "fedora-updates-container-aarch64-*": {
             "arch": "aarch64",
             "flavor": "updates-container",
@@ -104,10 +130,7 @@
         },
         "fedora-updates-container-x86_64-*": {
             "arch": "x86_64",
-            "flavor": "updates-container",
-            "settings": {
-                "KIWI_PROFILE": "Container-Base-Generic"
-            }
+            "flavor": "updates-container"
         },
         "fedora-updates-everything-boot-iso-x86_64-*": {
             "arch": "x86_64",
@@ -162,6 +185,18 @@
         }
     },
     "Profiles": {
+        "fedora-updates-cloud-aarch64-*-aarch64": {
+            "machine": "aarch64",
+            "product": "fedora-updates-cloud-aarch64-*"
+        },
+        "fedora-updates-cloud-ppc64le-*-ppc64le": {
+            "machine": "ppc64le",
+            "product": "fedora-updates-cloud-ppc64le-*"
+        },
+        "fedora-updates-cloud-x86_64-*-64bit": {
+            "machine": "64bit",
+            "product": "fedora-updates-cloud-x86_64-*"
+        },
         "fedora-updates-container-aarch64-*-aarch64": {
             "machine": "aarch64",
             "product": "fedora-updates-container-aarch64-*"
@@ -258,6 +293,7 @@
             "fedora-updates-workstation-x86_64-*-64bit": 0
         },
         "updates-base-tests": {
+            "fedora-updates-cloud-x86_64-*-64bit": 0,
             "updates-server-3arch": 0,
             "updates-desktops": 0
         }
@@ -415,6 +451,7 @@
         },
         "kiwi_build": {
             "profiles": {
+                "fedora-updates-cloud-x86_64-*-64bit": 5,
                 "fedora-updates-container-x86_64-*-64bit": 5,
                 "fedora-updates-kde-live-iso-x86_64-*-64bit": 5,
                 "fedora-updates-workstation-live-iso-x86_64-*-64bit": 5
@@ -431,6 +468,7 @@
                 "QEMUCPUS": "4",
                 "QEMURAM": "8192",
                 "ROOT_PASSWORD": "weakpassword",
+                "+START_AFTER_TEST": "",
                 "USER_LOGIN": "false"
             }
         },

--- a/tests/_kiwi_build.pm
+++ b/tests/_kiwi_build.pm
@@ -32,8 +32,8 @@ sub run {
     my $kiwiprofile = get_var("KIWI_PROFILE");
     my $workarounds = get_workarounds;
     my $isolation = 'nspawn';
-    # lives need simple isolation and permissive selinux, sadly
-    if (index($kiwiprofile, 'Live') != -1) {
+    # lives/cloud need simple isolation and permissive selinux, sadly
+    if (index($kiwiprofile, 'Live') != -1 || index($kiwiprofile, 'Cloud') != -1) {
         assert_script_run "setenforce Permissive";
         $isolation = 'simple';
     }
@@ -82,7 +82,8 @@ sub run {
     my %expected_formats = (
         'KDE-Desktop-Live' => 'iso',
         'Workstation-Live' => 'iso',
-        'Container-Base-Generic' => 'oci.tar.xz'
+        'Container-Base-Generic' => 'oci.tar.xz',
+        'Cloud-Base-Generic' => 'qcow2'
     );
     my $format = $expected_formats{$kiwiprofile};
     my $fname = "Fedora.${arch}-${releasever}.${format}";
@@ -93,6 +94,14 @@ sub run {
         # Kiwi
         my $subv = get_var("SUBVARIANT");
         my $newfname = "Fedora-${subv}-Live-${arch}-${advortask}.iso";
+        assert_script_run "mv ${fname} ${newfname}";
+        $fname = $newfname;
+    }
+    if (index($kiwiprofile, 'Cloud') != -1) {
+        # rename to the format expected by the base tests
+        my $flavor = get_var("FLAVOR");
+        my $machine = get_var("MACHINE");
+        my $newfname = "disk_${flavor}_${machine}.qcow2";
         assert_script_run "mv ${fname} ${newfname}";
         $fname = $newfname;
     }


### PR DESCRIPTION
This makes us create a generic cloud disk image and then run tests on it, just like we do for Workstation and KDE lives, everything netinst, Silverblue, and a container image. This is intended to help avoid anything like
https://bugzilla.redhat.com/show_bug.cgi?id=2390898 happening again - if we'd had these tests set up and gating enabled, the update that caused that bug would've been gated.

This requires some changes that affect other things: bind mounting the whole of /dev in our mock config, and forcing START_AFTER_TEST to "" for kiwi_build (this is needed to override the setting of it in the updates-cloud flavor). bind mounting is what koji does for 'real' kiwi build jobs so it's fine (in fact, better); previously the mock config was shared with livemedia-creator, but we don't use that any more so it's not a problem.

It's a bit icky when we get to the point of having *multiple* +START_AFTER_TEST settings, but I can't see another way to get everything right here and still share the test suite definition with compose tests.

Moving the definition of KIWI_PROFILE for container tests is not strictly related, but I noticed it was weird while working on this and couldn't leave it alone.