### PR TITLE
post_fail_hook: also upload AVCs and a text journal dump (#410)

### DIFF
--- a/lib/installedtest.pm
+++ b/lib/installedtest.pm
@@ -126,6 +126,16 @@ sub post_fail_hook {
         upload_logs "/tmp/var_log.tar.gz";
     }
 
+    # Also upload a text dump of the journal, for convenience
+    unless (script_run "journalctl > /var/tmp/journal.txt") {
+        upload_logs "/var/tmp/journal.txt";
+    }
+
+    # ...and AVCs
+    unless (script_run 'ausearch -m avc -ts yesterday > /tmp/avcs.txt 2>&1') {
+        upload_logs "/tmp/avcs.txt";
+    }
+
     # Sometimes useful for diagnosing FreeIPA issues
     upload_logs "/etc/nsswitch.conf", failok => 1;
 


### PR DESCRIPTION
@kparal pointed out that it's a bit inconvenient to quickly check the journal and any SELinux AVCs for a failed test. All the info is in the /var/log tarball, but you have to download it, extract it, and know how to run journalctl on it. For convenience, this adds a text dump of the journal and one of any AVCs found with ausearch.