### PR TITLE
Run unwanted_packages on KDE, they don't want gtk2 (#425)

### DIFF
--- a/templates.fif.json
+++ b/templates.fif.json
@@ -2551,6 +2551,7 @@
         },
         "unwanted_packages": {
             "profile_groups": {
+                "kde-all": 40,
                 "workstation-all": 40
             },
             "settings": {

--- a/tests/unwanted_packages.pm
+++ b/tests/unwanted_packages.pm
@@ -12,6 +12,9 @@ sub run {
     if ($subv eq "Workstation") {
         @unwanteds = ("gtk2", "qt");
     }
+    elsif ($subv eq "KDE") {
+        @unwanteds = ("gtk2");
+    }
     for my $unwanted (@unwanteds) {
         assert_script_run "! rpm -q $unwanted";
     }


### PR DESCRIPTION
This enables the unwanted_packages test we set up for Workstation a while ago on KDE as well. They want to ensure gtk2 isn't on KDE installs.