### PR TITLE
Fix install_rdp_server on aarch64 by passing console=tty0

### DIFF
--- a/templates.fif.json
+++ b/templates.fif.json
@@ -4,6 +4,7 @@
             "backend": "qemu",
             "settings": {
                 "ARCH_BASE_MACHINE": "64bit",
+                "CONSOLE_EXTRA_ARGS": "",
                 "MINCPU": "Nehalem",
                 "PART_TABLE_TYPE": "mbr",
                 "QEMUCPU": "host",
@@ -21,6 +22,7 @@
             "backend": "qemu",
             "settings": {
                 "ARCH_BASE_MACHINE": "aarch64",
+                "CONSOLE_EXTRA_ARGS": "console=tty0",
                 "INSECURE_PFLASH_CODE": "/usr/share/edk2/aarch64/QEMU_EFI-pflash.raw",
                 "INSECURE_PFLASH_VARS": "/usr/share/edk2/aarch64/vars-template-pflash.raw",
                 "MINCPU": "host",
@@ -45,6 +47,7 @@
             "backend": "qemu",
             "settings": {
                 "ARCH_BASE_MACHINE": "ppc64le",
+                "CONSOLE_EXTRA_ARGS": "",
                 "MINCPU": "host",
                 "OFW": 1,
                 "PART_TABLE_TYPE": "mbr",
@@ -61,6 +64,7 @@
             "backend": "qemu",
             "settings": {
                 "ARCH_BASE_MACHINE": "64bit",
+                "CONSOLE_EXTRA_ARGS": "",
                 "INSECURE_PFLASH_CODE": "/usr/share/edk2/ovmf/OVMF_CODE_4M.qcow2",
                 "INSECURE_PFLASH_VARS": "/usr/share/edk2/ovmf/OVMF_VARS_4M.qcow2",
                 "MINCPU": "Nehalem",
@@ -1919,7 +1923,7 @@
                 "server-dvd-3arch": 40
             },
             "settings": {
-                "GRUB": "inst.rdp inst.rdp.username=rapunzel inst.rdp.password=towertop net.ifnames=0 biosdevname=0 ip=172.16.2.114::172.16.2.2:255.255.255.0:rdp001.test.openqa.fedoraproject.org:eth0:off",
+                "GRUB": "inst.rdp inst.rdp.username=rapunzel inst.rdp.password=towertop net.ifnames=0 biosdevname=0 ip=172.16.2.114::172.16.2.2:255.255.255.0:rdp001.test.openqa.fedoraproject.org:eth0:off %CONSOLE_EXTRA_ARGS%",
                 "NICTYPE": "tap",
                 "RDP_SERVER": "1",
                 "WORKER_CLASS": "tap"


### PR DESCRIPTION
This is a bit ugly but I can't think of another way to pass it only on aarch64. Could try and factor out the other various instances of the string against this variable, I guess, but I don't feel like it right now.