### PR TITLE
desktop_login: use validate_script_output for whoami check

### DIFF
--- a/tests/desktop_login.pm
+++ b/tests/desktop_login.pm
@@ -134,7 +134,7 @@ sub check_user_logged_in {
         send_key("esc");
         assert_screen("apps_run_terminal");
     }
-    assert_script_run('[ $(whoami) = "' . "$user\" ]");
+    validate_script_output 'whoami', sub { m/^$user$/ };
     send_key $exitkey unless ($args{keepterm});
     wait_still_screen 5;
 }


### PR DESCRIPTION
The current version of this requires typing a lot of shifted characters, which often causes typing failures at a graphical console, especially on aarch64. We cannot pass a slower typing speed through assert_script_run, unfortunately (I may send that upstream as a PR later). Let's use validate_script_output and check the output instead, because then the command is just 'whoami', which is shorter and has no shifted characters, so less to go wrong.