### PR TITLE
static network: disable greenboot on IoT (#2396605)

### DIFF
--- a/tests/_post_network_static.pm
+++ b/tests/_post_network_static.pm
@@ -6,6 +6,11 @@ use utils;
 
 sub run {
     my $self = shift;
+    # stop greenboot to avoid
+    # https://bugzilla.redhat.com/show_bug.cgi?id=2396605
+    if (get_var("SUBVARIANT") eq "IoT") {
+        script_run "systemctl stop greenboot-set-rollback-trigger.service greenboot-healthcheck.service";
+    }
     my ($ip, $hostname) = split(/ /, get_var("POST_STATIC"));
     $hostname //= 'localhost.localdomain';
     # set up networking


### PR DESCRIPTION
In IoT F43 and F44 at present, greenboot is failing if networking is not immediately available on boot. Well, on our tests that use static networking, it isn't. So that's a problem. Let's have the static networking setup test stop greenboot if it's running on IoT, that should get around this.